### PR TITLE
upgrade markdown link button

### DIFF
--- a/asana-favicon-notification.js
+++ b/asana-favicon-notification.js
@@ -1,12 +1,12 @@
 // ==UserScript==
 // @name         Asana Dynamic Favicon
 // @namespace    https://github.com/jpbochi/user-scripts
-// @version      0.1.1
+// @version      0.1.2
 // @description  Displays an orange notification circle (just like Asana Inbox tab does) on the top right of the tab favicon.
 // @author       JP Bochi
 // @match        https://app.asana.com/*
 // @grant        none
-// @run-at       document-body
+// @run-at       document-idle
 // @icon         https://external-content.duckduckgo.com/i/asana.com.ico
 // @downloadURL  https://raw.githubusercontent.com/jpbochi/user-scripts/master/asana-favicon-notification.js
 // @updateURL    https://raw.githubusercontent.com/jpbochi/user-scripts/master/asana-favicon-notification.js

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -3,9 +3,10 @@
 // @namespace    https://github.com/jpbochi/user-scripts
 // @version      1.3.0
 // @description  Adds 3 helper buttons, plus paste in markdown format.
+// @author       Nick Goossens, JP Bochi, Karl K
 // @match        https://app.asana.com/*
 // @grant        none
-// @author       Nick Goossens, JP Bochi, Karl K
+// @run-at       document-idle
 // @require      https://cdn.jsdelivr.net/npm/marked@4.3.0/lib/marked.umd.min.js
 // @icon         https://external-content.duckduckgo.com/i/asana.com.ico
 // @downloadURL  https://raw.githubusercontent.com/jpbochi/user-scripts/master/asana-helpers-markdown.js
@@ -42,6 +43,7 @@
       .map(mutation => mutation.addedNodes)
       .flatMap(nodes => Array.from(nodes || []))
   );
+
   const queryAll = (nodes, query) => (
     [
       ...nodes.filter(node => node.matches && node.matches(query)),

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -49,6 +49,13 @@
     ]
   );
 
+  const animateButton = (button) => {
+    button.animate(
+      [{ transform: 'rotate(0)' }, { transform: 'rotate(360deg)' }],
+      { duration: 250, iterations: 1 }
+    );
+  }
+
   window.addEventListener('load', () => {
     var cssObj = {
       position: 'absolute',
@@ -194,14 +201,11 @@
     console.info('=>> Pasting…', markdown);
     await navigator.clipboard.writeText(markdown);
 
-    ev.srcElement.animate(
-      [{ transform: 'rotate(0)' }, { transform: 'rotate(360deg)' }],
-      { duration: 250, iterations: 1 }
-    );
+    animateButton(ev.srcElement);
   }
 
   // Switch between dark and light themes
-  function switchTheme() {
+  function switchTheme(ev) {
     const currentTheme = document.body.classList;
 
     const targetTheme = (
@@ -220,6 +224,7 @@
     currentTheme.add(targetTheme);
 
     setButtonsTheme(document.getElementById(buttonDivId));
+    animateButton(ev.srcElement);
   }
 
   function setButtonsTheme(buttonDiv) {
@@ -239,7 +244,7 @@
   }
 
   // Expand all comments and show all their details
-  function showAllComments() {
+  function showAllComments(ev) {
     var elements = document.getElementsByClassName('TaskStoryFeed-expandLink');
 
     for (var index = 0; index < elements.length; ++index) {
@@ -253,6 +258,7 @@
     for (var i = 1; i <= 5; i++) {
       setTimeout(showComments, i * 100);
     }
+    animateButton(ev.srcElement);
   }
 
   function showComments() {

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Asana Helpers - Markdown, Expand Comments, Theme Switch
 // @namespace    https://github.com/jpbochi/user-scripts
-// @version      1.2.4
+// @version      1.3.0
 // @description  Adds 3 helper buttons, plus paste in markdown format.
 // @match        https://app.asana.com/*
 // @grant        none
@@ -15,46 +15,62 @@
 (function () {
   'use strict';
 
-  // Setup the UI
-  let buttonDiv = null; // Setting a default state, even if its null
+  const buttonDivId = '__helpers_div__';
 
-  const button = (content, onClick) => {
+  const button = (content, onClick, title) => {
     var btn = document.createElement('button');
     btn.innerHTML = content;
+    btn.setAttribute('title', title || '');
     btn.onclick = onClick;
+    btn.onauxclick = onClick;
     return btn;
   };
 
   const separator = () => {
     var sep = document.createElement('div');
-    sep.innerHTML = '&nbsp;|&nbsp;';
+    sep.innerHTML = '&nbsp;&nbsp;';
     sep.style.setProperty('display', 'inline-block');
     sep.style.setProperty('opacity', '0.5');
     sep.style.setProperty('margin', '0 4px');
     return sep;
   };
 
+  // Helper functions for https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+  const getAddedNodes = (mutations) => (
+    Array.from(mutations)
+      .filter(mutation => (mutation.type === 'childList'))
+      .map(mutation => mutation.addedNodes)
+      .flatMap(nodes => Array.from(nodes || []))
+  );
+  const queryAll = (nodes, query) => (
+    [
+      ...nodes.filter(node => node.matches && node.matches(query)),
+      ...nodes.flatMap(node => Array.from(node.querySelectorAll ? node.querySelectorAll(query) : [])),
+    ]
+  );
+
   window.addEventListener('load', () => {
     var cssObj = {
       position: 'absolute',
       top: '7px',
       left: '172px',
-      padding: '8px 12px',
+      padding: '5px 12px',
       'border-radius': '999px',
       'z-index': 50, // Setting to 50 just in case there are other elements with z-index 1
-      fontSize: '14px',
+      fontSize: '16px',
     };
-    buttonDiv = document.createElement('div');
+    const buttonDiv = document.createElement('div');
+    buttonDiv.id = buttonDivId;
     setButtonsTheme(buttonDiv);
     Object.keys(cssObj).forEach((key) => {
       buttonDiv.style[key] = cssObj[key];
     });
 
-    buttonDiv.appendChild(button('Theme', switchTheme));
+    buttonDiv.appendChild(button('☯', switchTheme, 'Switch dark/light themes.'));
     buttonDiv.appendChild(separator());
-    buttonDiv.appendChild(button('Expand', showAllComments));
+    buttonDiv.appendChild(button('↕', showAllComments, 'Expand all comments.'));
     buttonDiv.appendChild(separator());
-    buttonDiv.appendChild(button('MD', getMDLink));
+    buttonDiv.appendChild(button('🔗', getMDLink, 'Copy task/message link as Markdown. With Meta/Ctrl, opens it on a new tab.'));
 
     document.body.appendChild(buttonDiv);
   });
@@ -119,14 +135,69 @@
     return null;
   }
 
+  const waitForSuccessNotification = () => (new Promise((resolve, _reject) => {
+    const observer = new MutationObserver((mutations) => {
+      const addedNodes = getAddedNodes(mutations);
+
+      const [notification] = queryAll(addedNodes, '.ToastNotificationContent');
+      if (notification) {
+        observer.disconnect();
+        console.debug('=>> Found notification.', { notification });
+        return resolve(notification);
+      }
+      console.debug('=>> Mutation, but notification?', { mutations });
+    });
+
+    const notificationsDiv = document.querySelector('.ToastManager');
+    console.debug('=>> Observing…', notificationsDiv);
+    observer.observe(notificationsDiv, { subtree: true, childList: true });
+  }));
+
+  const getCurrentTaskUrlFromCopyLinkButton = async () => {
+    const observerWaiting = waitForSuccessNotification();
+    document.querySelector('.TaskPaneToolbar-copyLinkButton,.ConversationToolbar-copyLinkButton').click();
+
+    console.info('=>> Waiting for copied link…');
+    await observerWaiting;
+    console.info('=>> Reading copied link…');
+    const href = await navigator.clipboard.readText();
+    console.debug('=>> Read:', { href }); // TODO: should we verify that the href is actually an URL pointing to app.asana.com?
+    return href;
+  }
+
+  const getCurrentTaskUrlFromPage = async () => {
+    const taskPane = document.querySelector('.TaskPane[data-task-id]');
+    if (taskPane) {
+      const taskId = taskPane.getAttribute('data-task-id');
+      return `https://app.asana.com/0/0/${taskId}/f`;
+    }
+
+    const conversationLink = document.querySelector('.ConversationPane .ConversationTitleAndContext-title a[href]')
+    if (conversationLink) return conversationLink.href;
+
+    // Fallback to Asana's "Copy Link" button.
+    return await getCurrentTaskUrlFromCopyLinkButton();
+  }
+
   // Get a Markdown link for the current task formatted as [Task Title](Link)
-  function getMDLink() {
-    var text = document.getElementsByClassName('TaskPaneToolbarAnimation-title')[0].innerText;
-    var location = window.location;
+  const getMDLink = async (ev) => {
+    console.debug('=>> Click:', ev);
+    const href = await getCurrentTaskUrlFromPage();
 
-    var markdown = `[${text}](${location})`;
+    if (ev.metaKey || ev.ctrlKey || ev.altKey || (ev.button === 1)) { // meta for MacOS, ctrl for Windows, middle click, or alt for good measure
+      console.info('=>> Opening tab…', { href });
+      return window.open(href, '_blank').focus();
+    }
 
-    navigator.clipboard.writeText(markdown);
+    var title = document.querySelector('.TaskPaneToolbarAnimation-title,.ConversationTitleAndContext-title').innerText;
+    var markdown = `[${title}](${href})`;
+    console.info('=>> Pasting…', markdown);
+    await navigator.clipboard.writeText(markdown);
+
+    ev.srcElement.animate(
+      [{ transform: 'rotate(0)' }, { transform: 'rotate(360deg)' }],
+      { duration: 250, iterations: 1 }
+    );
   }
 
   // Switch between dark and light themes
@@ -148,7 +219,7 @@
     );
     currentTheme.add(targetTheme);
 
-    setButtonsTheme(buttonDiv);
+    setButtonsTheme(document.getElementById(buttonDivId));
   }
 
   function setButtonsTheme(buttonDiv) {

--- a/only-single-comments.js
+++ b/only-single-comments.js
@@ -1,11 +1,12 @@
 // ==UserScript==
 // @name         Only Single Comments
 // @namespace    https://github.com/jpbochi/user-scripts
-// @version      1.0.6
+// @version      1.0.7
 // @description  On GitHub PR inline comments, changes the default button from "Start a review" to "Add single comment"
 // @author       JP Bochi
 // @match        https://github.com/*/*/pull/*
 // @grant        none
+// @run-at       document-idle
 // @icon         https://external-content.duckduckgo.com/i/github.com.ico
 // @downloadURL  https://raw.githubusercontent.com/jpbochi/user-scripts/master/only-single-comments.js
 // @updateURL    https://raw.githubusercontent.com/jpbochi/user-scripts/master/only-single-comments.js


### PR DESCRIPTION
Changes include here (sorry for bundling all in one commit):

- Markdown link will use shorter URLs like `https://app.asana.com/0/0/${taskId}/f`.
- Markdown link also works on the Inbox, when viewing either a task or a message.
- Markdown link button will open current task or message in a new tab, when either:
  - clicking it with `Cmd` or `Ctrl` or `Alt`;
  - clicking with the mouse's middle-button.
- Markdown link button will perform a smal animation, as a feedback that it did its job.
- Replaced button texts with single unicode emoji-like chars, with a `title` so that a description pop-up is displayed on hover. Buttons look like images below.

![image](https://github.com/jpbochi/user-scripts/assets/96475/ed0bd1cf-c71a-4ae2-93c4-c9436de3a425)
![image](https://github.com/jpbochi/user-scripts/assets/96475/1ceca537-4c5b-488a-a2c2-a48923bb1db1)
