### PR TITLE
Asana - button to toggle task editor read-only or not

### DIFF
--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -54,7 +54,10 @@
     button.animate([{ transform: 'rotate(0)' }, { transform: 'rotate(360deg)' }], { duration: 250, iterations: 1 });
   };
 
-  window.addEventListener('load', () => {
+  const setupButtons = () => {
+    const preexisting = document.getElementById(buttonDivId);
+    if (preexisting) return;
+
     var cssObj = {
       position: 'absolute',
       top: '0.44rem',
@@ -79,7 +82,12 @@
     document.body.appendChild(buttonDiv);
 
     waitForEditorThenConfigureIt();
-  });
+    window.removeEventListener('focus', setupButtons);
+  };
+
+  window.addEventListener('load', setupButtons);
+  window.addEventListener('pageshow', setupButtons);
+  window.addEventListener('focus', setupButtons);
 
   navigation.addEventListener('navigate', () => {
     console.debug('=>> navigate event. Refreshing readonly button state in 99ms…');
@@ -246,7 +254,7 @@
     const editable = (
       (assignee === userSelf) || (creator === userSelf)
     );
-    console.info('==> Configuring task editor.', { editable, assigneeInitials, userSelfInitials, creatorInitials, });
+    console.info('==> Configuring task editor.', JSON.stringify({ editable, assigneeInitials, userSelfInitials, creatorInitials }));
     taskEditor.setAttribute('contenteditable', editable);
 
     const editorToolbar = taskEditor.parentElement.querySelector('.TextEditorFixedToolbar');

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -18,9 +18,10 @@
 
   const buttonDivId = '__helpers_div__';
 
-  const button = (content, onClick, title) => {
+  const button = (content, klass, onClick, title) => {
     var btn = document.createElement('button');
     btn.innerHTML = content;
+    btn.classList.add(klass);
     btn.setAttribute('title', title || '');
     btn.onclick = onClick;
     btn.onauxclick = onClick;
@@ -69,15 +70,20 @@
       buttonDiv.style[key] = cssObj[key];
     });
 
-    buttonDiv.appendChild(button('\u262F', switchTheme, 'Switch dark/light themes.'));
+    buttonDiv.appendChild(button('\u262F', '__theme', switchTheme, 'Switch dark/light themes.'));
     buttonDiv.appendChild(separator());
-    buttonDiv.appendChild(button('\u2195', showAllComments, 'Expand all comments.'));
+    buttonDiv.appendChild(button('\u2195', '__expand', showAllComments, 'Expand all comments.'));
     buttonDiv.appendChild(separator());
-    buttonDiv.appendChild(button('\u29C9', getMDLink, 'Copy task/message link as Markdown. With Meta/Ctrl, opens it on a new tab.'));
+    buttonDiv.appendChild(button('\u29C9', '__md_link', getMDLink, 'Copy task/message link as Markdown. With Meta/Ctrl, opens it on a new tab.'));
     buttonDiv.appendChild(separator());
-    buttonDiv.appendChild(button('\u{1F4DD}', toggleReadOnly, 'Toggles task\'s contenteditable on/off.'));
+    buttonDiv.appendChild(button('\u{1F4DD}', '__readonly', toggleReadOnly, 'Toggles task\'s contenteditable on/off.'));
 
     document.body.appendChild(buttonDiv);
+  });
+
+  navigation.addEventListener('navigate', () => {
+    console.debug('=>> navigate event. Refreshing readonly button state in 99ms…');
+    setTimeout(refreshReadOnlyState, 99);
   });
 
   // Handle Markdown paste. If the content it already text/html it is pasted as it to allow
@@ -204,17 +210,22 @@
     animateButton(ev.srcElement);
   };
 
-  const toggleReadOnly = async (ev) => {
+  const refreshReadOnlyState = () => {
     const taskEditable = document.querySelector('#TaskDescriptionView .ProseMirror');
-    if (!taskEditable) {
-      return;
-    }
-    const editable = taskEditable.getAttribute('contenteditable') !== 'true';
-    taskEditable.setAttribute('contenteditable', editable);
+    const button = document.querySelector(`#${buttonDivId} .__readonly`);
+    if (!taskEditable || !button) return;
 
-    // '\u{1F4DD}' = 📝
-    // '\u{1F4D6}' = 📖
-    ev.srcElement.innerHTML = editable ? '\u{1F4DD}' : '\u{1F4D6}';
+    // '\u{1F4DD}' = 📝; '\u{1F4D6}' = 📖
+    const editable = taskEditable.getAttribute('contenteditable') === 'true';
+    button.innerHTML = editable ? '\u{1F4DD}' : '\u{1F4D6}';
+  };
+
+  const toggleReadOnly = (ev) => {
+    const taskEditable = document.querySelector('#TaskDescriptionView .ProseMirror');
+    const editable = taskEditable.getAttribute('contenteditable') === 'true';
+    taskEditable.setAttribute('contenteditable', !editable);
+
+    refreshReadOnlyState();
     animateButton(ev.srcElement);
   };
 

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -74,6 +74,8 @@
     buttonDiv.appendChild(button('\u2195', showAllComments, 'Expand all comments.'));
     buttonDiv.appendChild(separator());
     buttonDiv.appendChild(button('\u29C9', getMDLink, 'Copy task/message link as Markdown. With Meta/Ctrl, opens it on a new tab.'));
+    buttonDiv.appendChild(separator());
+    buttonDiv.appendChild(button('\u{1F4DD}', toggleReadOnly, 'Toggles task\'s contenteditable on/off.'));
 
     document.body.appendChild(buttonDiv);
   });
@@ -199,6 +201,20 @@
     console.info('=>> Pasting…', markdown);
     await navigator.clipboard.writeText(markdown);
 
+    animateButton(ev.srcElement);
+  };
+
+  const toggleReadOnly = async (ev) => {
+    const taskEditable = document.querySelector('#TaskDescriptionView .ProseMirror');
+    if (!taskEditable) {
+      return;
+    }
+    const editable = taskEditable.getAttribute('contenteditable') !== 'true';
+    taskEditable.setAttribute('contenteditable', editable);
+
+    // '\u{1F4DD}' = 📝
+    // '\u{1F4D6}' = 📖
+    ev.srcElement.innerHTML = editable ? '\u{1F4DD}' : '\u{1F4D6}';
     animateButton(ev.srcElement);
   };
 

--- a/asana-helpers-markdown.js
+++ b/asana-helpers-markdown.js
@@ -217,6 +217,7 @@
     if (ev.metaKey || ev.ctrlKey || ev.altKey || ev.button === 1) {
       // meta for MacOS, ctrl for Windows, middle click, or alt for good measure
       console.info('=>> Opening tab…', { href });
+      animateButton(ev.srcElement);
       return window.open(href, '_blank').focus();
     }
 
@@ -224,7 +225,6 @@
     var markdown = `[${title}](${href})`;
     console.info('=>> Pasting…', markdown);
     await navigator.clipboard.writeText(markdown);
-
     animateButton(ev.srcElement);
   };
 


### PR DESCRIPTION
Implements https://github.com/jpbochi/user-scripts/discussions/8

By default, I'm making tasks read-only, unless the current user either created the task or is the assignee. As that default is probably not fit for everyone, I probably should make it configurable somehow.

For the time being, I'm running the version from this branch, and see how sensible that default is.

CC: @ngoossens

Screenshots of how the editor toolbar looks when it's in read-only mode:

![image](https://github.com/jpbochi/user-scripts/assets/96475/e2a16b69-feec-4670-8b05-d0830e0c6482)

![image](https://github.com/jpbochi/user-scripts/assets/96475/7e74e283-9934-4061-87ff-1363c53c7c8f)
