### PR TITLE
use more reliable methods to find repo URL path

### DIFF
--- a/only-single-comments.js
+++ b/only-single-comments.js
@@ -98,8 +98,12 @@
     // Object.fromEntries(Array.from(document.querySelectorAll('meta[property]')).map(x => [x.getAttribute('property'), x.content]))
 
     // '\u00B7' = '·'; '\u2022' = '•'
-    const repoPath = document.querySelector('meta[property="og:title"]').content.split(' ').pop();
-    const title = document.querySelector('h1.gh-header-title').innerText.replace(/#([0-9]+)$/, `\u2022 ${repoPath}#$1`);
+    const repoUrlPath = document.querySelector('#code-tab')?.pathname
+      || (
+        document.querySelector('head title')?.innerText
+        || document.querySelector('meta[property="og:title"]')?.content
+      )?.split(' ')?.pop();
+    const title = document.querySelector('h1.gh-header-title').innerText.replace(/#([0-9]+)$/, `\u2022 ${repoUrlPath}#$1`);
 
     var markdown = `[${title}](${href})`;
     console.info('=>> Pasting…', { markdown });

--- a/only-single-comments.js
+++ b/only-single-comments.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Only Single Comments
 // @namespace    https://github.com/jpbochi/user-scripts
-// @version      1.2.1
+// @version      1.2.2
 // @description  On GitHub PR inline comments, changes the default button from "Start a review" to "Add single comment"
 // @author       JP Bochi
 // @match        *://github.com/**


### PR DESCRIPTION
Like on https://github.com/jpbochi/user-scripts/pull/18, the `meta[property="og:*"]` elements are unreliable.

If one opens a PR page, then navigates to another PR, those meta properties still mention the first PR because GitHub doesn't update the `<head>` elements when dynamically navigating around. Similarly, depending on the first visited page, those elements may not even be present.